### PR TITLE
feat: Add README and initial test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# GNOME AI Assistant: An AI-Powered Productivity Tool for GNOME
+
+GNOME AI Assistant is an alpha-stage AI-powered productivity tool integrated into the GNOME Shell environment. It aims to provide users with quick access to AI text generation, context-aware assistance, and basic command execution.
+
+## Features
+
+*   **AI-Powered Text Generation:** Leverage language models for tasks like summarization, translation, and creative writing.
+*   **Context Awareness:** Utilizes the current window title and clipboard content to provide relevant assistance.
+*   **Basic Command Execution:** Can launch applications and perform simple system commands (with user confirmation).
+
+## Prerequisites
+
+*   **GNOME Shell:** Version 42-46 (ensure compatibility with your specific version).
+*   **Python:** Version 3.8 or newer.
+*   **pip:** Python package installer (usually comes with Python).
+*   **GNOME Shell Extension Manager:** Recommended for easy installation and management of the extension.
+
+## Installation Instructions
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone https://github.com/DigitalDemocracyInitiative/LINUXGNOMEOSAGENT.git
+    ```
+
+2.  **Navigate into the Directory:**
+    ```bash
+    cd LINUXGNOMEOSAGENT
+    ```
+
+3.  **Install GNOME Extension:**
+    *   Copy the extension directory:
+        ```bash
+        cp -r GnomeAIAssistant@digitaldemocracyinitiative.com ~/.local/share/gnome-shell/extensions/
+        ```
+    *   Restart GNOME Shell: Press `Alt+F2`, type `r` in the dialog, and press Enter. If this doesn't work (e.g., on Wayland), you may need to log out and log back in.
+
+4.  **Install Python Dependencies:**
+    *   Navigate to the Python directory:
+        ```bash
+        cd python
+        ```
+    *   Install dependencies:
+        ```bash
+        pip install -r requirements.txt
+        ```
+    *   **Note:** The first time you run the backend or install requirements, the `distilgpt2` model (or other specified models) will be downloaded. This may take some time depending on your internet connection.
+
+## Running the Assistant
+
+1.  **Start the Backend Server:**
+    *   Navigate to the `python` directory if you aren't already there:
+        ```bash
+        cd /path/to/LINUXGNOMEOSAGENT/python # Or navigate from your current location
+        ```
+    *   Run the Python application:
+        ```bash
+        python app.py
+        ```
+    *   **Keep this terminal window open.** The backend server needs to be running for the extension to function.
+
+2.  **Enable the GNOME Extension:**
+    *   Open the GNOME Extensions application (usually found in your app grid) or use the GNOME Shell Extension Manager.
+    *   Search for "GNOME AI Assistant".
+    *   Enable the extension by toggling the switch.
+    *   A new button/icon for the AI Assistant should appear in your top panel.
+
+## Usage / Testing Instructions
+
+1.  **Activate the Assistant:** Click the AI Assistant icon in the GNOME top panel. A text input field will appear.
+2.  **Type Your Query:** Enter your request or question into the text field and press Enter.
+
+    **Examples:**
+    *   Copy a block of text to your clipboard, then type: `Summarize this text`
+    *   `Open Firefox`
+    *   `Launch Terminal`
+    *   `What is the capital of France?`
+
+3.  **Responses and Actions:**
+    *   AI-generated text responses will appear as system notifications.
+    *   If the assistant interprets your query as an action (e.g., "Open Firefox"), a confirmation dialog will appear. You must click "Confirm" for the action to be executed.
+
+## Troubleshooting
+
+*   **Extension Not Appearing in GNOME Extensions App:**
+    *   Ensure you copied the `GnomeAIAssistant@digitaldemocracyinitiative.com` directory correctly to `~/.local/share/gnome-shell/extensions/`.
+    *   Verify your GNOME Shell version is compatible (42-46). Check with `gnome-shell --version`.
+    *   Make sure you've restarted GNOME Shell (`Alt+F2`, then `r`, or logout/login).
+
+*   **Backend Not Starting or Not Responding:**
+    *   Check if port `5000` is already in use by another application. You can change the port in `python/app.py` if needed.
+    *   Ensure `pip install -r requirements.txt` (inside the `python` directory) completed successfully without errors.
+    *   Look for error messages in the terminal where you ran `python python/app.py`.
+
+*   **No AI Response / Extension Seems Unresponsive:**
+    *   Verify the Python backend server (`python/app.py`) is still running in its terminal.
+    *   Check if the extension is enabled in the GNOME Extensions app.
+    *   Ensure your system can connect to `http://localhost:5000`. You can test this by opening this URL in a web browser (you should see a "Not Found" error or similar, which means the server is running but that specific path isn't directly browsable).
+
+*   **Model Download Issues During `pip install`:**
+    *   Ensure you have a stable internet connection.
+    *   Firewall or proxy settings might be blocking the download.
+    *   Try running `pip install -r requirements.txt` again.
+
+## Known Limitations
+
+*   **Limited Context Retrieval:** Full window content retrieval is not currently supported due to Wayland and X11 security restrictions. The assistant's context is primarily limited to the active window's title and the content of your clipboard.
+*   **Action Confirmation:** All actions require explicit user confirmation via a dialog box for security reasons.
+*   **Wayland vs. X11:** Some functionalities or workarounds might behave differently between Wayland and X11 sessions.
+
+*Future work may explore integration with D-Bus-enabled applications (e.g., LibreOffice, text editors) for richer contextual understanding and more direct interaction, where permitted by application APIs.*
+
+## Future Enhancements (Optional)
+
+*   More robust intent and action detection.
+*   Improved user interface and user experience.
+*   Background loading of AI models to reduce initial startup time.
+*   Support for more complex, multi-step commands.
+*   Customizable user preferences.
+
+---
+
+*This is an alpha version. Expect bugs and incomplete features. Your feedback is valuable!*

--- a/test_extension.sh
+++ b/test_extension.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Log file for the script's output
+LOG_FILE="test_log.txt"
+exec &> >(tee -a "$LOG_FILE")
+
+# Log file for the backend server
+SERVER_LOG_FILE="python/server.log"
+PYTHON_APP_PATH="python/app.py"
+BASE_URL="http://localhost:5000"
+BACKEND_PID=""
+
+echo "----------------------------------------------------"
+echo "Starting GNOME AI Assistant Test Script"
+echo "Timestamp: $(date)"
+echo "----------------------------------------------------"
+
+# Ensure python directory exists
+if [ ! -d "python" ]; then
+    echo "Error: 'python' directory not found. Make sure you are in the LINUXGNOMEOSAGENT root."
+    exit 1
+fi
+
+# Ensure the python app exists
+if [ ! -f "$PYTHON_APP_PATH" ]; then
+    echo "Error: Python backend script '$PYTHON_APP_PATH' not found."
+    exit 1
+fi
+
+# Function to clean up and stop the backend server
+cleanup() {
+    echo ""
+    echo "----------------------------------------------------"
+    echo "Cleaning up..."
+    if [ ! -z "$BACKEND_PID" ]; then
+        echo "Stopping backend server (PID: $BACKEND_PID)..."
+        kill $BACKEND_PID
+        # Wait a moment for the process to terminate
+        sleep 2
+        if ps -p $BACKEND_PID > /dev/null; then
+            echo "Backend server did not stop gracefully, sending SIGKILL..."
+            kill -9 $BACKEND_PID
+        else
+            echo "Backend server stopped."
+        fi
+    else
+        echo "Backend PID not found, skipping kill."
+    fi
+    echo "Test script finished."
+    echo "----------------------------------------------------"
+}
+
+# Set trap to call cleanup function on script exit (normal or interrupt)
+trap cleanup EXIT SIGINT SIGTERM
+
+# 1. Start the Flask Backend
+echo ""
+echo "Step 1: Starting the Flask backend server..."
+# Create server log directory if it doesn't exist
+mkdir -p "$(dirname "$SERVER_LOG_FILE")"
+touch "$SERVER_LOG_FILE" # Ensure log file exists for tail
+
+if [ -f "$SERVER_LOG_FILE" ]; then
+    echo "Clearing previous server log: $SERVER_LOG_FILE"
+    > "$SERVER_LOG_FILE"
+fi
+
+# Start the server in the background
+(cd python && python3 app.py &> "../$SERVER_LOG_FILE" &)
+BACKEND_PID=$!
+
+if [ -z "$BACKEND_PID" ]; then
+    echo "ERROR: Failed to start backend server."
+    exit 1
+fi
+echo "Backend server started with PID: $BACKEND_PID. Logging to: $SERVER_LOG_FILE"
+echo "Waiting a few seconds for the server to initialize..."
+sleep 5 # Initial wait for server to start up
+
+# 2. Wait for Backend Readiness
+echo ""
+echo "Step 2: Waiting for backend readiness..."
+MAX_RETRIES=20 # Approx 20 * 3 = 60 seconds
+RETRY_COUNT=0
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    echo "Attempting to connect to backend (Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
+    # We expect a 400 or 500 error if 'text' is missing, or 200 if it processes an empty request (depends on backend)
+    # A connection refused error means it's not up yet.
+    RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" -X POST -H "Content-Type: application/json" -d '{"text": "ping"}' $BASE_URL/process_text)
+
+    if [ "$RESPONSE_CODE" -eq 200 ] || [ "$RESPONSE_CODE" -eq 400 ] || [ "$RESPONSE_CODE" -eq 500 ] ; then
+        echo "Backend is responsive (HTTP Code: $RESPONSE_CODE)."
+        break
+    else
+        echo "Backend not ready yet (HTTP Code: $RESPONSE_CODE). Retrying in 3 seconds..."
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+        sleep 3
+    fi
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "ERROR: Backend server did not become ready after $MAX_RETRIES attempts."
+    echo "Please check $SERVER_LOG_FILE for errors."
+    exit 1
+fi
+
+# 3. Enable GNOME Extension
+echo ""
+echo "Step 3: Enabling GNOME Extension..."
+EXTENSION_ID="GnomeAIAssistant@digitaldemocracyinitiative.com"
+if gnome-extensions list --enabled | grep -q "$EXTENSION_ID"; then
+    echo "Extension '$EXTENSION_ID' is already enabled."
+else
+    echo "Attempting to enable extension: $EXTENSION_ID"
+    gnome-extensions enable "$EXTENSION_ID"
+    if [ $? -eq 0 ]; then
+        echo "Successfully sent command to enable extension."
+        echo "Please verify in GNOME if the extension icon appears in the top panel."
+    else
+        echo "Warning: Failed to execute gnome-extensions enable command. The extension might not be installed correctly, or you might be in a non-graphical environment."
+        echo "You may need to enable it manually via the GNOME Extensions app."
+    fi
+fi
+# Give a moment for the extension to potentially load
+sleep 3
+
+# 4. Simulate User Input (Basic Text Query)
+echo ""
+echo "Step 4: Simulating basic user input (direct POST to backend)..."
+echo "Note: Full UI simulation (e.g., typing in the GNOME extension's text field and clicking buttons) is complex and beyond the scope of this basic alpha test script. Manual testing is required for UI interaction."
+
+TEST_QUERY='{"text": "What is the capital of France?", "context": {"window_title": "Test Script", "clipboard_content": "Some test clipboard data"}}'
+echo "Sending query to backend: $TEST_QUERY"
+curl_response_text=$(curl --silent -X POST -H "Content-Type: application/json" -d "$TEST_QUERY" $BASE_URL/process_text)
+
+if [ $? -eq 0 ]; then
+    echo "Backend response for text query:"
+    echo "$curl_response_text"
+    # Basic check for expected part of response (adapt if backend response structure is known)
+    if echo "$curl_response_text" | grep -iq "Paris"; then
+        echo "SUCCESS: Backend response seems to contain expected information for 'Capital of France'."
+    else
+        echo "NOTE: Backend response for text query did not contain 'Paris'. This might be okay depending on the model's current output or if it's a non-question task."
+    fi
+else
+    echo "ERROR: Failed to send text query to backend."
+fi
+
+# 5. Simulate an Action Prompt
+echo ""
+echo "Step 5: Simulating an action prompt (direct POST to backend)..."
+ACTION_QUERY='{"text": "Open Firefox", "context": {"window_title": "Test Script Action"}}'
+echo "Sending action query to backend: $ACTION_QUERY"
+curl_response_action=$(curl --silent -X POST -H "Content-Type: application/json" -d "$ACTION_QUERY" $BASE_URL/process_text)
+
+if [ $? -eq 0 ]; then
+    echo "Backend response for action query:"
+    echo "$curl_response_action"
+    # This part of the test primarily verifies the backend's action detection.
+    # The script cannot automatically click the confirmation dialog in GNOME.
+    if echo "$curl_response_action" | grep -iq "action" ; then # Assuming response contains an 'action' field
+         echo "SUCCESS: Backend response suggests an action was detected."
+         echo "MANUAL STEP REQUIRED: If the extension is working, a confirmation dialog should appear on your GNOME desktop to 'Open Firefox'. Please check and confirm/cancel it manually."
+    else
+        echo "WARNING: Backend response for action query did not seem to indicate a detected action. Check backend logic."
+    fi
+else
+    echo "ERROR: Failed to send action query to backend."
+fi
+
+echo ""
+echo "----------------------------------------------------"
+echo "Basic tests complete."
+echo "Please check $LOG_FILE for detailed logs of this script."
+echo "Please check $SERVER_LOG_FILE for backend server logs."
+echo "Further manual testing of the GNOME UI interactions is recommended."
+echo "----------------------------------------------------"
+
+# Cleanup will be called automatically on exit by the trap
+exit 0


### PR DESCRIPTION
Added a comprehensive README.md with installation, usage, and troubleshooting instructions for the GNOME AI Assistant.

Also added test_extension.sh, a bash script to perform basic automated checks:
- Starts the Python backend.
- Waits for backend readiness.
- Attempts to enable the GNOME extension.
- Simulates text and action queries directly to the backend.
- Logs output and handles cleanup.